### PR TITLE
[LATERA-426] Total logging revamp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.DS_Store
+.idea/*
+.project
+activiti-ext.iml
+dst/*

--- a/build.xml
+++ b/build.xml
@@ -9,20 +9,6 @@
   <property name="dst.build" location="${dst}/build" />
   <property name="dst.lib" location="${dst}/lib" />
 
-<!--
-  <property name="groovy.home" value="/usr/share/groovy" />
-  <property name="groovy.version" value="1.8.6" />
-  <property name="java.libs" value="/usr/share/java" />
-  <path id="groovy.classpath">
-    <fileset dir="${groovy.home}/embeddable">
-      <include name="groovy-all-${groovy.version}.jar" />
-    </fileset>
-    <fileset dir="${java.libs}">
-      <include name="commons-logging.jar" />
-    </fileset>
-  </path>
-  <taskdef name="groovyc" classname="org.codehaus.groovy.ant.Groovyc" classpathref="groovy.classpath" />
--->
   <property name="groovy.home" value="/usr/local/share/groovy" />
   <property name="groovy.version" value="2.4.12" />
   <property name="java.libs" value="/usr/local/share/java" />

--- a/build.xml
+++ b/build.xml
@@ -23,7 +23,7 @@
   </path>
   <taskdef name="groovyc" classname="org.codehaus.groovy.ant.Groovyc" classpathref="groovy.classpath" />
 -->
-  <property name="groovy.home" value="/usr/local/Cellar/groovy" />
+  <property name="groovy.home" value="/usr/local/share/groovy" />
   <property name="groovy.version" value="2.4.12" />
   <property name="java.libs" value="/usr/local/share/java" />
   <path id="groovy.classpath">

--- a/build.xml
+++ b/build.xml
@@ -9,11 +9,25 @@
   <property name="dst.build" location="${dst}/build" />
   <property name="dst.lib" location="${dst}/lib" />
 
+<!--
   <property name="groovy.home" value="/usr/share/groovy" />
   <property name="groovy.version" value="1.8.6" />
   <property name="java.libs" value="/usr/share/java" />
   <path id="groovy.classpath">
     <fileset dir="${groovy.home}/embeddable">
+      <include name="groovy-all-${groovy.version}.jar" />
+    </fileset>
+    <fileset dir="${java.libs}">
+      <include name="commons-logging.jar" />
+    </fileset>
+  </path>
+  <taskdef name="groovyc" classname="org.codehaus.groovy.ant.Groovyc" classpathref="groovy.classpath" />
+-->
+  <property name="groovy.home" value="/usr/local/Cellar/groovy" />
+  <property name="groovy.version" value="2.4.12" />
+  <property name="java.libs" value="/usr/local/share/java" />
+  <path id="groovy.classpath">
+    <fileset dir="${groovy.home}/${groovy.version}/libexec/embeddable">
       <include name="groovy-all-${groovy.version}.jar" />
     </fileset>
     <fileset dir="${java.libs}">

--- a/src/bss/eventListeners/abstract_listener.groovy
+++ b/src/bss/eventListeners/abstract_listener.groovy
@@ -4,34 +4,30 @@ import org.activiti.engine.delegate.event.*
 import org.activiti.engine.delegate.DelegateExecution
 
 public class AbstractListener implements ActivitiEventListener {
-  ActivitiEvent event
-  DelegateExecution execution
-  
+
   def public void onEvent(ActivitiEvent event) {
-    this.event = event
-    this.execution = getExecution()
-    
-    execute()
+    def execution = getExecution(event)
+
+    execute(execution, event)
   }
 
-  def protected execute() {
+  def protected execute(DelegateExecution execution, ActivitiEvent event) {
     // do stuff
   }
 
-  def protected getExecution() {
+  def protected getExecution(ActivitiEvent event) {
     def execution = null
-    
+
     def executionId = event.getExecutionId()
     if (executionId) {
       execution = event.getEngineServices().getRuntimeService().createExecutionQuery().executionId(executionId).singleResult()
     }
-    
     execution
   }
-  
-  def protected log(String msg, String level = "info") {
-    def logger = getLogger()
-    
+
+  def protected log(String msg, String level = "info", DelegateExecution execution) {
+    def logger = getLogger(execution)
+
     if (logger) {
       logger."${level}"(msg)
     } else {
@@ -39,9 +35,9 @@ public class AbstractListener implements ActivitiEventListener {
     }
   }
 
-  def protected getLogger() {
+  def protected getLogger(DelegateExecution execution) {
     def logger = null
-    
+
     if (execution) {
       logger = execution.getVariable("logger")
     }

--- a/src/bss/eventListeners/abstract_listener.groovy
+++ b/src/bss/eventListeners/abstract_listener.groovy
@@ -6,9 +6,7 @@ import org.activiti.engine.delegate.DelegateExecution
 public class AbstractListener implements ActivitiEventListener {
 
   def public void onEvent(ActivitiEvent event) {
-    def execution = getExecution(event)
-
-    execute(execution, event)
+    execute(getExecution(event), event)
   }
 
   def protected execute(DelegateExecution execution, ActivitiEvent event) {

--- a/src/bss/eventListeners/abstract_listener.groovy
+++ b/src/bss/eventListeners/abstract_listener.groovy
@@ -1,19 +1,15 @@
 package org.activiti.latera.bss.eventListeners
 
-import org.activiti.engine.delegate.event.*
-import org.activiti.engine.delegate.DelegateExecution
+import org.activiti.engine.delegate.event.ActivitiEventListener
+import org.activiti.engine.delegate.event.ActivitiEvent
 
-public class AbstractListener implements ActivitiEventListener {
+class AbstractListener implements ActivitiEventListener {
 
-  def public void onEvent(ActivitiEvent event) {
-    execute(getExecution(event), event)
+  void onEvent(ActivitiEvent event) {
+    // Do stuff
   }
 
-  def protected execute(DelegateExecution execution, ActivitiEvent event) {
-    // do stuff
-  }
-
-  def protected getExecution(ActivitiEvent event) {
+  static protected getExecution(ActivitiEvent event) {
     def execution = null
 
     def executionId = event.getExecutionId()
@@ -23,28 +19,7 @@ public class AbstractListener implements ActivitiEventListener {
     execution
   }
 
-  def protected log(String msg, String level = "info", DelegateExecution execution) {
-    def logger = getLogger(execution)
-
-    if (logger) {
-      logger."${level}"(msg)
-    } else {
-      println msg
-    }
-  }
-
-  def protected getLogger(DelegateExecution execution) {
-    def logger = null
-
-    if (execution) {
-      logger = execution.getVariable("logger")
-    }
-
-    logger
-  }
-
-  def public boolean isFailOnException() {
+  boolean isFailOnException() {
     false
   }
 }
-

--- a/src/bss/eventListeners/abstract_listener.groovy
+++ b/src/bss/eventListeners/abstract_listener.groovy
@@ -49,3 +49,4 @@ public class AbstractListener implements ActivitiEventListener {
     false
   }
 }
+

--- a/src/bss/eventListeners/event_logging.groovy
+++ b/src/bss/eventListeners/event_logging.groovy
@@ -1,49 +1,41 @@
 package org.activiti.latera.bss.eventListeners
+import org.activiti.engine.delegate.DelegateExecution
 
 import org.activiti.latera.bss.eventListeners.AbstractListener
 import org.activiti.engine.delegate.event.*
 import org.activiti.engine.delegate.event.impl.*
 
+import org.slf4j.LoggerFactory
+
 public class EventLogging extends AbstractListener {
-  def protected execute() {
+  def protected execute(DelegateExecution execution, ActivitiEvent event) {
+
     def logStr = "Occured ${event.getType()} event"
 
-    def detailedLogStr = getDetailedLog()
+    def detailedLogStr = getDetailedLog(event)
     if (detailedLogStr) {
       logStr = "${logStr}: ${detailedLogStr}"
     }
 
-    log logStr
+    log(logStr, 'debug', execution)
   }
 
-  def private getDetailedLog() {
+  def private getDetailedLog(ActivitiEvent event) {
     def detailedLog = null
     
     switch (event) {
       case ActivitiActivityEventImpl:
-        detailedLog = getActivityLog()
+        detailedLog = "${event.getActivityId()} (${event.getActivityType()} - ${event.getActivityName()})"
         break
       case ActivitiEntityEvent:
-        detailedLog = getEntityLog()
+        detailedLog = event.getEntity().getClass().name
         break
       case ActivitiVariableEvent:
-        detailedLog = getVariableLog()
+        detailedLog = "${event.getVariableName()} = ${event.getVariableValue()} (${event.getVariableType()})"
         break
     }
     
     detailedLog
-  }
-  
-  def private getActivityLog() {
-    "${event.getActivityId()} (${event.getActivityType()} - ${event.getActivityName()})"
-  }
-
-  def private getEntityLog() {
-    event.getEntity().getClass().name
-  }
-  
-  def private getVariableLog() {
-    "${event.getVariableName()} = ${event.getVariableValue()} (${event.getVariableType()})"
   }
 
   def public boolean isFailOnException() {

--- a/src/bss/eventListeners/event_logging.groovy
+++ b/src/bss/eventListeners/event_logging.groovy
@@ -25,17 +25,29 @@ public class EventLogging extends AbstractListener {
     
     switch (event) {
       case ActivitiActivityEventImpl:
-        detailedLog = "${event.getActivityId()} (${event.getActivityType()} - ${event.getActivityName()})"
+        detailedLog = getActivityLog(event)
         break
       case ActivitiEntityEvent:
-        detailedLog = event.getEntity().getClass().name
+        detailedLog = getEntityLog(event)
         break
       case ActivitiVariableEvent:
-        detailedLog = "${event.getVariableName()} = ${event.getVariableValue()} (${event.getVariableType()})"
+        detailedLog = getVariableLog(event)
         break
     }
     
     detailedLog
+  }
+
+  def private getActivityLog(ActivitiEvent event) {
+    "${event.getActivityId()} (${event.getActivityType()} - ${event.getActivityName()})"
+  }
+
+  def private getEntityLog(ActivitiEvent event) {
+    event.getEntity().getClass().name
+  }
+
+  def private getVariableLog(ActivitiEvent event) {
+    "${event.getVariableName()} = ${event.getVariableValue()} (${event.getVariableType()})"
   }
 
   def public boolean isFailOnException() {

--- a/src/bss/eventListeners/event_logging.groovy
+++ b/src/bss/eventListeners/event_logging.groovy
@@ -1,28 +1,24 @@
 package org.activiti.latera.bss.eventListeners
-import org.activiti.engine.delegate.DelegateExecution
 
-import org.activiti.latera.bss.eventListeners.AbstractListener
-import org.activiti.engine.delegate.event.*
-import org.activiti.engine.delegate.event.impl.*
+import org.activiti.engine.delegate.event.ActivitiEvent
+import org.activiti.engine.delegate.event.impl.ActivitiActivityEventImpl
+import org.activiti.engine.delegate.event.ActivitiEntityEvent
+import org.activiti.engine.delegate.event.ActivitiVariableEvent
+import org.activiti.latera.bss.logging.Logging
 
-import org.slf4j.LoggerFactory
+class EventLogging extends AbstractListener {
 
-public class EventLogging extends AbstractListener {
-  def protected execute(DelegateExecution execution, ActivitiEvent event) {
-
-    def logStr = "Occured ${event.getType()} event"
-
+  void onEvent(ActivitiEvent event) {
+    def logStr = "Occurred ${event.getType()} event"
     def detailedLogStr = getDetailedLog(event)
     if (detailedLogStr) {
       logStr = "${logStr}: ${detailedLogStr}"
     }
-
-    log(logStr, 'debug', execution)
+    Logging.log(logStr, 'info', Logging.getLogger(event))
   }
 
-  def private getDetailedLog(ActivitiEvent event) {
+  static private getDetailedLog(ActivitiEvent event) {
     def detailedLog = null
-    
     switch (event) {
       case ActivitiActivityEventImpl:
         detailedLog = getActivityLog(event)
@@ -34,23 +30,18 @@ public class EventLogging extends AbstractListener {
         detailedLog = getVariableLog(event)
         break
     }
-    
     detailedLog
   }
 
-  def private getActivityLog(ActivitiEvent event) {
+  static private getActivityLog(ActivitiEvent event) {
     "${event.getActivityId()} (${event.getActivityType()} - ${event.getActivityName()})"
   }
 
-  def private getEntityLog(ActivitiEvent event) {
+  static private getEntityLog(ActivitiEvent event) {
     event.getEntity().getClass().name
   }
 
-  def private getVariableLog(ActivitiEvent event) {
+  static private getVariableLog(ActivitiEvent event) {
     "${event.getVariableName()} = ${event.getVariableValue()} (${event.getVariableType()})"
-  }
-
-  def public boolean isFailOnException() {
-    false
   }
 }

--- a/src/bss/executionListeners/abstract_listener.groovy
+++ b/src/bss/executionListeners/abstract_listener.groovy
@@ -21,13 +21,9 @@ public class AbstractListener implements ExecutionListener {
   }
 
   def protected getLogger(DelegateExecution execution) {
-    def logger = null
-
     if (execution) {
-      logger = execution.getVariable("logger")
+      execution.getVariable("logger")
     }
-
-    logger
   }
 }
 

--- a/src/bss/executionListeners/abstract_listener.groovy
+++ b/src/bss/executionListeners/abstract_listener.groovy
@@ -3,22 +3,30 @@ package org.activiti.latera.bss.executionListeners
 import org.activiti.engine.delegate.*
 
 public class AbstractListener implements ExecutionListener {
-  DelegateExecution execution
 
   def public void notify(DelegateExecution execution) {
-    this.execution = execution
-    execute()
+    execute(execution)
   }
-  
-  def protected execute() {
+
+  def protected execute(execution) {
     // do stuff
   }
 
-  def protected log(String msg, String level = "info") {
-    def logger = execution.getVariable("logger")
+  def protected log(String msg, String level = "info", DelegateExecution execution = null) {
+    def logger = getLogger(execution)
 
     if (logger) {
       logger."${level}"(msg)
     }
+  }
+
+  def protected getLogger(DelegateExecution execution) {
+    def logger = null
+
+    if (execution) {
+      logger = execution.getVariable("logger")
+    }
+
+    logger
   }
 }

--- a/src/bss/executionListeners/abstract_listener.groovy
+++ b/src/bss/executionListeners/abstract_listener.groovy
@@ -8,7 +8,7 @@ public class AbstractListener implements ExecutionListener {
     execute(execution)
   }
 
-  def protected execute(execution) {
+  def protected execute(DelegateExecution execution) {
     // do stuff
   }
 
@@ -30,3 +30,4 @@ public class AbstractListener implements ExecutionListener {
     logger
   }
 }
+

--- a/src/bss/executionListeners/abstract_listener.groovy
+++ b/src/bss/executionListeners/abstract_listener.groovy
@@ -1,29 +1,11 @@
 package org.activiti.latera.bss.executionListeners
 
-import org.activiti.engine.delegate.*
+import org.activiti.engine.delegate.ExecutionListener
+import org.activiti.engine.delegate.DelegateExecution
 
-public class AbstractListener implements ExecutionListener {
+class AbstractListener implements ExecutionListener {
 
-  def public void notify(DelegateExecution execution) {
-    execute(execution)
-  }
-
-  def protected execute(DelegateExecution execution) {
+  void notify(DelegateExecution execution) {
     // do stuff
   }
-
-  def protected log(String msg, String level = "info", DelegateExecution execution = null) {
-    def logger = getLogger(execution)
-
-    if (logger) {
-      logger."${level}"(msg)
-    }
-  }
-
-  def protected getLogger(DelegateExecution execution) {
-    if (execution) {
-      execution.getVariable("logger")
-    }
-  }
 }
-

--- a/src/bss/executionListeners/init_logging.groovy
+++ b/src/bss/executionListeners/init_logging.groovy
@@ -10,7 +10,7 @@ public class InitLogging extends AbstractListener {
     Logging.log("Logger initialized", "info", logger)
   }
 
-  def notify(DelegateExecution execution) {
+  void notify(DelegateExecution execution) {
     testLogger(Logging.getLogger(execution))
   }
 }

--- a/src/bss/executionListeners/init_logging.groovy
+++ b/src/bss/executionListeners/init_logging.groovy
@@ -4,19 +4,19 @@ import org.activiti.latera.bss.executionListeners.AbstractListener
 import org.slf4j.LoggerFactory
 
 public class InitLogging extends AbstractListener {
-  def initLogger() {
-    def processId = "${execution.getProcessDefinitionId()} (${execution.getProcessInstanceId()})"
-    def logger = LoggerFactory.getLogger(processId)
-    
-    execution.setVariable("logger", logger)
-  }
-  
-  def testLogger() {
-    log "Logger initialized"
-  }
+    def initLogger(execution) {
+        def processId = "${execution.getProcessDefinitionId()} (${execution.getProcessInstanceId()})"
+        def logger = LoggerFactory.getLogger(processId)
 
-  def execute() {
-    initLogger()
-    testLogger()
-  }
+        execution.setVariable("logger", logger)
+    }
+
+    def testLogger(execution) {
+        log("Logger initialized", "info", execution)
+    }
+
+    def execute(execution) {
+        initLogger(execution)
+        testLogger(execution)
+    }
 }

--- a/src/bss/executionListeners/init_logging.groovy
+++ b/src/bss/executionListeners/init_logging.groovy
@@ -4,19 +4,20 @@ import org.activiti.latera.bss.executionListeners.AbstractListener
 import org.slf4j.LoggerFactory
 
 public class InitLogging extends AbstractListener {
-    def initLogger(execution) {
-        def processId = "${execution.getProcessDefinitionId()} (${execution.getProcessInstanceId()})"
-        def logger = LoggerFactory.getLogger(processId)
+  def initLogger(execution) {
+    def processId = "${execution.getProcessDefinitionId()} (${execution.getProcessInstanceId()})"
+    def logger = LoggerFactory.getLogger(processId)
 
-        execution.setVariable("logger", logger)
-    }
+    execution.setVariable("logger", logger)
+  }
 
-    def testLogger(execution) {
-        log("Logger initialized", "info", execution)
-    }
+  def testLogger(execution) {
+    log("Logger initialized", "info", execution)
+  }
 
-    def execute(execution) {
-        initLogger(execution)
-        testLogger(execution)
-    }
+  def execute(execution) {
+    initLogger(execution)
+    testLogger(execution)
+  }
 }
+

--- a/src/bss/executionListeners/init_logging.groovy
+++ b/src/bss/executionListeners/init_logging.groovy
@@ -1,21 +1,22 @@
 package org.activiti.latera.bss.executionListeners
 
 import org.activiti.latera.bss.executionListeners.AbstractListener
+import org.activiti.engine.delegate.DelegateExecution
 import org.slf4j.LoggerFactory
 
 public class InitLogging extends AbstractListener {
-  def initLogger(execution) {
+  def initLogger(DelegateExecution execution) {
     def processId = "${execution.getProcessDefinitionId()} (${execution.getProcessInstanceId()})"
     def logger = LoggerFactory.getLogger(processId)
 
     execution.setVariable("logger", logger)
   }
 
-  def testLogger(execution) {
+  def testLogger(DelegateExecution execution) {
     log("Logger initialized", "info", execution)
   }
 
-  def execute(execution) {
+  def execute(DelegateExecution execution) {
     initLogger(execution)
     testLogger(execution)
   }

--- a/src/bss/executionListeners/init_logging.groovy
+++ b/src/bss/executionListeners/init_logging.groovy
@@ -1,24 +1,16 @@
 package org.activiti.latera.bss.executionListeners
 
-import org.activiti.latera.bss.executionListeners.AbstractListener
 import org.activiti.engine.delegate.DelegateExecution
-import org.slf4j.LoggerFactory
+import org.activiti.latera.bss.logging.Logging
+import org.slf4j.Logger
 
 public class InitLogging extends AbstractListener {
-  def initLogger(DelegateExecution execution) {
-    def processId = "${execution.getProcessDefinitionId()} (${execution.getProcessInstanceId()})"
-    def logger = LoggerFactory.getLogger(processId)
 
-    execution.setVariable("logger", logger)
+  def testLogger(Logger logger) {
+    Logging.log("Logger initialized", "info", logger)
   }
 
-  def testLogger(DelegateExecution execution) {
-    log("Logger initialized", "info", execution)
-  }
-
-  def execute(DelegateExecution execution) {
-    initLogger(execution)
-    testLogger(execution)
+  def notify(DelegateExecution execution) {
+    testLogger(Logging.getLogger(execution))
   }
 }
-

--- a/src/bss/http.groovy
+++ b/src/bss/http.groovy
@@ -12,7 +12,6 @@ public class HTTPRestProcessor {
 
   def HTTPRestProcessor(parameters) {
     this.httpClient = new RESTClient(parameters.baseUrl)
-    this.httpClient.ignoreSSLIssues()
   }
 
   def protected log(String msg, String level = "info", DelegateExecution execution = null) {
@@ -24,13 +23,9 @@ public class HTTPRestProcessor {
   }
 
   def protected getLogger(DelegateExecution execution) {
-    def logger = null
-
     if (execution) {
-      logger = execution.getVariable("logger")
+      execution.getVariable("logger")
     }
-
-    logger
   }
 
   def private responseBlock(failure=false, DelegateExecution execution=null) {

--- a/src/bss/http.groovy
+++ b/src/bss/http.groovy
@@ -8,36 +8,45 @@ import java.io.InputStreamReader
 import org.apache.commons.io.IOUtils
 
 public class HTTPRestProcessor {
-  DelegateExecution execution
   public RESTClient httpClient
- 
+
   def HTTPRestProcessor(parameters) {
-    this.execution = parameters.execution
     this.httpClient = new RESTClient(parameters.baseUrl)
+    this.httpClient.ignoreSSLIssues()
   }
 
-  def private log(String msg, String level = "info") {
-    def logger = execution.getVariable('logger')
+  def protected log(String msg, String level = "info", DelegateExecution execution = null) {
+    def logger = getLogger(execution)
 
     if (logger) {
       logger."${level}"(msg)
     }
   }
 
-  def private responseBlock(failure=false) {
+  def protected getLogger(DelegateExecution execution) {
+    def logger = null
+
+    if (execution) {
+      logger = execution.getVariable("logger")
+    }
+
+    logger
+  }
+
+  def private responseBlock(failure=false, DelegateExecution execution=null) {
     {resp, reader ->
       def respStatusLine = resp.statusLine
 
-      log "Response status: ${respStatusLine}"
-      log "Response data: -----"
+      log("Response status: ${respStatusLine}", "info", execution)
+      log("Response data: -----", "info", execution)
       if (reader) {
         if (reader instanceof InputStreamReader) {
-          log IOUtils.toString(reader); 
+          log(IOUtils.toString(reader), "info", execution)
         } else {
-          log reader.toString()
+          log(reader.toString(), "info", execution)
         }
       }
-      log "--------------------"
+      log("--------------------", "info", execution)
 
       if (failure) {
         throw new HttpResponseException(resp)
@@ -46,24 +55,27 @@ public class HTTPRestProcessor {
       }
     }
   }
-  
+
   def public sendRequest(params, String method) {
+    def execution = params.execution
+    params.remove('execution')
+
     if (!params.requestContentType) {
       params.requestContentType = ContentType.JSON
     }
-    
-    log "/ Sending HTTP ${method.toUpperCase()} request (${httpClient.defaultURI}${params.path})..."
+
+    log("/ Sending HTTP ${method.toUpperCase()} request (${httpClient.defaultURI}${params.path})...", "info", params.execution)
     if (params.body) {
-      log "Request data: ------"
-      log params.body.toString()
-      log "--------------------"
+      log("Request data: ------", "info", execution)
+      log(params.body.toString(), "info", execution)
+      log("--------------------", "info", execution)
     }
 
-    httpClient.handler.success = responseBlock()
-    httpClient.handler.failure = responseBlock(true)
-    
+    httpClient.handler.success = responseBlock(false, execution)
+    httpClient.handler.failure = responseBlock(true, execution)
+
     def result = httpClient."${method}"(params)
-    log "\\ HTTP request sent"
+    log("\\ HTTP request sent", "info", execution)
     result
   }
 }

--- a/src/bss/logging.groovy
+++ b/src/bss/logging.groovy
@@ -1,0 +1,26 @@
+package org.activiti.latera.bss.logging
+
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
+class Logging {
+
+  static Logger getLogger(entity) {
+    Logger logger = null
+    try {
+      String processId = "${entity.getProcessDefinitionId()} (${entity.getProcessInstanceId()})"
+      logger = LoggerFactory.getLogger(processId)
+    }
+    finally {
+      logger
+    }
+  }
+
+  static void log(String msg, String level = "info", Logger logger = null) {
+    if (logger) {
+      logger."${level}"(msg)
+    } else {
+      println("[${level}] ${msg}")
+    }
+  }
+}

--- a/src/homs/eventListeners/auto_save_order_data.groovy
+++ b/src/homs/eventListeners/auto_save_order_data.groovy
@@ -2,7 +2,7 @@ package org.activiti.latera.homs.eventListeners
 
 import org.activiti.latera.bss.eventListeners.AbstractListener
 import org.activiti.latera.bss.http.HTTPRestProcessor
-import org.activiti.engine.delegate.event.*
+import org.activiti.engine.delegate.event.ActivitiEvent
 import org.activiti.engine.delegate.DelegateExecution
 
 
@@ -11,9 +11,8 @@ public class AutoSaveOrderData extends AbstractListener {
   def execute(DelegateExecution execution, ActivitiEvent event) {
     if (isSavePossible(execution)) {
       def orderData = getOrderData(execution)
-      def orderDataBuffer = execution.getVariable('homsOrdDataBuffer')
 
-      if (orderData != orderDataBuffer) {
+      if (orderData != execution.getVariable('homsOrdDataBuffer')) {
         log('/ Saving order data...', "info", execution)
         saveOrderData(orderData, execution)
         execution.setVariable('homsOrdDataBuffer', orderData)

--- a/src/homs/eventListeners/auto_save_order_data.groovy
+++ b/src/homs/eventListeners/auto_save_order_data.groovy
@@ -2,65 +2,61 @@ package org.activiti.latera.homs.eventListeners
 
 import org.activiti.latera.bss.eventListeners.AbstractListener
 import org.activiti.latera.bss.http.HTTPRestProcessor
+import org.activiti.engine.delegate.event.*
+import org.activiti.engine.delegate.DelegateExecution
+
 
 public class AutoSaveOrderData extends AbstractListener {
-  def execute() {
-    if (!isSavePossible()) return
-    
-    def orderData = getOrderData()
-    def orderDataBuffer = getOrderDataBuffer()
 
-    if (orderData != orderDataBuffer) {
-      log '/ Saving order data...'
-      saveOrderData(orderData)
-      saveOrderDataBuffer(orderData)
-      log '\\ Order data saved'
-    } else {
-      log 'Order data has not changed, save not needed'
+  def execute(DelegateExecution execution, ActivitiEvent event) {
+    if (isSavePossible(execution)) {
+      def orderData = getOrderData(execution)
+      def orderDataBuffer = execution.getVariable('homsOrdDataBuffer')
+
+      if (orderData != orderDataBuffer) {
+        log('/ Saving order data...', "info", execution)
+        saveOrderData(orderData, execution)
+        execution.setVariable('homsOrdDataBuffer', orderData)
+        log('\\ Order data saved', "info", execution)
+      } else {
+        log('Order data has not changed, save not needed', "info", execution)
+      }
     }
   }
 
-  def private isSavePossible() {
-    execution && execution.getVariable('homsOrderCode') && getOrderDataBuffer()
+  def private isSavePossible(DelegateExecution execution) {
+    execution && execution.getVariable('homsOrderCode') && execution.getVariable('homsOrdDataBuffer')
   }
-  
-  def private getOrderData() {
+
+  def private getOrderData(DelegateExecution execution) {
     def orderData = [:]
-    
+
     for (e in execution.getVariables()) {
       if (!e.key.startsWith('homsOrderData')) continue
-      
+
       def dataKey = e.key.replaceFirst(/^homsOrderData/, "")
       dataKey = (dataKey.getAt(0).toLowerCase() + dataKey.substring(1)).toString()
       orderData[dataKey] = e.value
     }
-    
+
     orderData
   }
-  
-  def private getOrderDataBuffer() {
-    execution.getVariable('homsOrdDataBuffer')
-  }
-  
-  def private saveOrderData(orderData) {
+
+  def private saveOrderData(orderData, execution) {
     def homsUrl = execution.getVariable('homsUrl')
     def homsUser = execution.getVariable('homsUser')
     def homsPassword = execution.getVariable('homsPassword')
     def homsOrderCode = execution.getVariable('homsOrderCode')
-    
+
     def homsRequestObj = [
-      order: [
-        data: orderData
-      ]
+        order: [
+            data: orderData
+        ]
     ]
 
-    def httpProcessor = new HTTPRestProcessor(execution: execution, baseUrl: "$homsUrl/api/")
+    def httpProcessor = new HTTPRestProcessor(baseUrl: "$homsUrl/api/")
     httpProcessor.httpClient.auth.basic(homsUser, homsPassword)
-    httpProcessor.sendRequest('put', path: "orders/$homsOrderCode", body: homsRequestObj)
-  }
-  
-  def private saveOrderDataBuffer(orderData) {
-    execution.setVariable('homsOrdDataBuffer', orderData)
+    httpProcessor.sendRequest('put', path: "orders/$homsOrderCode", body: homsRequestObj, execution: execution)
   }
 
   def public boolean isFailOnException() {

--- a/src/homs/executionListeners/finish_order.groovy
+++ b/src/homs/executionListeners/finish_order.groovy
@@ -1,14 +1,18 @@
 package org.activiti.latera.homs.executionListeners
 
 import org.activiti.latera.bss.executionListeners.AbstractListener
-import org.activiti.engine.delegate.Expression
 import org.activiti.latera.bss.http.HTTPRestProcessor
 import org.activiti.engine.delegate.DelegateExecution
+import org.activiti.latera.bss.logging.Logging
 
-public class FinishOrder extends AbstractListener {
+class FinishOrder extends AbstractListener {
 
-  def finishOrder(def homsUrl, def homsUser, def homsPassword, def execution) {
+  def finishOrder(def execution, def logger) {
+    def homsUrl = execution.getVariable('homsUrl')
+    def homsUser = execution.getVariable('homsUser')
+    def homsPassword = execution.getVariable('homsPassword')
     def homsOrderCode = execution.getVariable('homsOrderCode')
+
     def homsRequestObj = [
       order: [
         state   : "done",
@@ -17,18 +21,17 @@ public class FinishOrder extends AbstractListener {
       ]
     ]
 
-    def httpProcessor = new HTTPRestProcessor(execution: execution, baseUrl: "$homsUrl/api/")
+    def httpProcessor = new HTTPRestProcessor(baseUrl: "$homsUrl/api/")
     httpProcessor.httpClient.auth.basic(homsUser, homsPassword)
-    httpProcessor.sendRequest('put', path: "orders/$homsOrderCode", body: homsRequestObj, execution: execution)
+    httpProcessor.sendRequest('put', path: "orders/$homsOrderCode", body: homsRequestObj, logger: logger)
   }
 
-  def execute(DelegateExecution execution) {
-    def homsUrl = execution.getVariable('homsUrl')
-    def homsUser = execution.getVariable('homsUser')
-    def homsPassword = execution.getVariable('homsPassword')
+  def notify(DelegateExecution execution) {
 
-    log('/ Finishing order...', "info", execution)
-    finishOrder(homsUrl, homsUser, homsPassword, execution)
-    log('\\ Order finished', "info", execution)
+    def logger = Logging.getLogger(execution)
+
+    Logging.log('/ Finishing order...', "info", logger)
+    finishOrder(execution, logger)
+    Logging.log('\\ Order finished', "info", logger)
   }
 }

--- a/src/homs/executionListeners/finish_order.groovy
+++ b/src/homs/executionListeners/finish_order.groovy
@@ -26,7 +26,7 @@ class FinishOrder extends AbstractListener {
     httpProcessor.sendRequest('put', path: "orders/$homsOrderCode", body: homsRequestObj, logger: logger)
   }
 
-  def notify(DelegateExecution execution) {
+  void notify(DelegateExecution execution) {
 
     def logger = Logging.getLogger(execution)
 

--- a/src/homs/executionListeners/finish_order.groovy
+++ b/src/homs/executionListeners/finish_order.groovy
@@ -5,37 +5,29 @@ import org.activiti.engine.delegate.Expression
 import org.activiti.latera.bss.http.HTTPRestProcessor
 
 public class FinishOrder extends AbstractListener {
-  private Expression homsUrl
-  private Expression homsUser
-  private Expression homsPassword
-  
-  def getParameterValue(def parameterName, def execution) {
-    def parameter = this."$parameterName"
-    parameter ? (String)parameter.getValue(execution) : execution.getVariable(parameterName)
-  }
-  
+
   def finishOrder(def homsUrl, def homsUser, def homsPassword, def execution) {
     def homsOrderCode = execution.getVariable('homsOrderCode')
     def homsRequestObj = [
       order: [
-        state: "done",
-        done_at: String.format("%tFT%<tRZ", Calendar.getInstance(TimeZone.getTimeZone("Z"))),
+        state   : "done",
+        done_at : String.format("%tFT%<tRZ", Calendar.getInstance(TimeZone.getTimeZone("Z"))),
         bp_state: "done"
       ]
     ]
 
     def httpProcessor = new HTTPRestProcessor(execution: execution, baseUrl: "$homsUrl/api/")
     httpProcessor.httpClient.auth.basic(homsUser, homsPassword)
-    httpProcessor.sendRequest('put', path: "orders/$homsOrderCode", body: homsRequestObj)
+    httpProcessor.sendRequest('put', path: "orders/$homsOrderCode", body: homsRequestObj, execution: execution)
   }
 
-  def execute() {
-    def homsUrl = getParameterValue('homsUrl', execution)
-    def homsUser = getParameterValue('homsUser', execution)
-    def homsPassword = getParameterValue('homsPassword', execution)
+  def execute(execution) {
+      def homsUrl = execution.getVariable('homsUrl')
+      def homsUser = execution.getVariable('homsUser')
+      def homsPassword = execution.getVariable('homsPassword')
 
-    log '/ Finishing order...'    
-    finishOrder(homsUrl, homsUser, homsPassword, execution)
-    log '\\ Order finished'
+      log('/ Finishing order...', "info", execution)
+      finishOrder(homsUrl, homsUser, homsPassword, execution)
+      log('\\ Order finished', "info", execution)
   }
 }

--- a/src/homs/executionListeners/finish_order.groovy
+++ b/src/homs/executionListeners/finish_order.groovy
@@ -3,6 +3,7 @@ package org.activiti.latera.homs.executionListeners
 import org.activiti.latera.bss.executionListeners.AbstractListener
 import org.activiti.engine.delegate.Expression
 import org.activiti.latera.bss.http.HTTPRestProcessor
+import org.activiti.engine.delegate.DelegateExecution
 
 public class FinishOrder extends AbstractListener {
 
@@ -21,7 +22,7 @@ public class FinishOrder extends AbstractListener {
     httpProcessor.sendRequest('put', path: "orders/$homsOrderCode", body: homsRequestObj, execution: execution)
   }
 
-  def execute(execution) {
+  def execute(DelegateExecution execution) {
     def homsUrl = execution.getVariable('homsUrl')
     def homsUser = execution.getVariable('homsUser')
     def homsPassword = execution.getVariable('homsPassword')

--- a/src/homs/executionListeners/finish_order.groovy
+++ b/src/homs/executionListeners/finish_order.groovy
@@ -22,12 +22,12 @@ public class FinishOrder extends AbstractListener {
   }
 
   def execute(execution) {
-      def homsUrl = execution.getVariable('homsUrl')
-      def homsUser = execution.getVariable('homsUser')
-      def homsPassword = execution.getVariable('homsPassword')
+    def homsUrl = execution.getVariable('homsUrl')
+    def homsUser = execution.getVariable('homsUser')
+    def homsPassword = execution.getVariable('homsPassword')
 
-      log('/ Finishing order...', "info", execution)
-      finishOrder(homsUrl, homsUser, homsPassword, execution)
-      log('\\ Order finished', "info", execution)
+    log('/ Finishing order...', "info", execution)
+    finishOrder(homsUrl, homsUser, homsPassword, execution)
+    log('\\ Order finished', "info", execution)
   }
 }

--- a/src/homs/executionListeners/get_order_data.groovy
+++ b/src/homs/executionListeners/get_order_data.groovy
@@ -27,7 +27,7 @@ class GetOrderData extends AbstractListener {
     execution.setVariable("homsOrdDataBuffer", orderData)
   }
 
-  def notify(DelegateExecution execution) {
+  void notify(DelegateExecution execution) {
     def logger = Logging.getLogger(execution)
 
     Logging.log('/ Receiving order data...', "info", logger)

--- a/src/homs/executionListeners/get_order_data.groovy
+++ b/src/homs/executionListeners/get_order_data.groovy
@@ -5,14 +5,6 @@ import org.activiti.engine.delegate.Expression
 import org.activiti.latera.bss.http.HTTPRestProcessor
 
 public class GetOrderData extends AbstractListener {
-  private Expression homsUrl
-  private Expression homsUser
-  private Expression homsPassword
-  
-  def getParameterValue(def parameterName, def execution) {
-    def parameter = this."$parameterName"
-    parameter ? (String)parameter.getValue(execution) : execution.getVariable(parameterName)
-  }
   
   def getOrderData(def homsUrl, def homsUser, def homsPassword, def execution) {
     def homsOrderCode = execution.getVariable('homsOrderCode')
@@ -20,7 +12,7 @@ public class GetOrderData extends AbstractListener {
     def httpProcessor = new HTTPRestProcessor(execution: execution, baseUrl: "$homsUrl/api/")
     httpProcessor.httpClient.auth.basic(homsUser, homsPassword)
 
-    def homsResp = httpProcessor.sendRequest('get', path: "orders/$homsOrderCode")
+    def homsResp = httpProcessor.sendRequest('get', path: "orders/$homsOrderCode", execution: execution)
     def orderObj = homsResp["order"]
     def orderData = orderObj["data"].collectEntries{[it.key, it.value]}
 
@@ -31,13 +23,13 @@ public class GetOrderData extends AbstractListener {
     execution.setVariable("homsOrdDataBuffer", orderData)
   }
 
-  def execute() {
-    def homsUrl = getParameterValue('homsUrl', execution)
-    def homsUser = getParameterValue('homsUser', execution)
-    def homsPassword = getParameterValue('homsPassword', execution)
-    
-    log '/ Receiving order data...'
+  def execute(execution) {
+    def homsUrl = execution.getVariable('homsUrl')
+    def homsUser = execution.getVariable('homsUser')
+    def homsPassword = execution.getVariable('homsPassword')
+
+    log('/ Receiving order data...', "info", execution)
     getOrderData(homsUrl, homsUser, homsPassword, execution)
-    log '\\ Order data received'
+    log('\\ Order data received', "info", execution)
   }
 }

--- a/src/homs/executionListeners/get_order_data.groovy
+++ b/src/homs/executionListeners/get_order_data.groovy
@@ -3,6 +3,7 @@ package org.activiti.latera.homs.executionListeners
 import org.activiti.latera.bss.executionListeners.AbstractListener
 import org.activiti.engine.delegate.Expression
 import org.activiti.latera.bss.http.HTTPRestProcessor
+import org.activiti.engine.delegate.DelegateExecution
 
 public class GetOrderData extends AbstractListener {
   
@@ -23,7 +24,7 @@ public class GetOrderData extends AbstractListener {
     execution.setVariable("homsOrdDataBuffer", orderData)
   }
 
-  def execute(execution) {
+  def execute(DelegateExecution execution) {
     def homsUrl = execution.getVariable('homsUrl')
     def homsUser = execution.getVariable('homsUser')
     def homsPassword = execution.getVariable('homsPassword')

--- a/src/homs/executionListeners/get_order_data.groovy
+++ b/src/homs/executionListeners/get_order_data.groovy
@@ -1,19 +1,22 @@
 package org.activiti.latera.homs.executionListeners
 
 import org.activiti.latera.bss.executionListeners.AbstractListener
-import org.activiti.engine.delegate.Expression
 import org.activiti.latera.bss.http.HTTPRestProcessor
 import org.activiti.engine.delegate.DelegateExecution
+import org.activiti.latera.bss.logging.Logging
 
-public class GetOrderData extends AbstractListener {
+class GetOrderData extends AbstractListener {
   
-  def getOrderData(def homsUrl, def homsUser, def homsPassword, def execution) {
+  def getOrderData(def execution, def logger) {
+    def homsUrl = execution.getVariable('homsUrl')
+    def homsUser = execution.getVariable('homsUser')
+    def homsPassword = execution.getVariable('homsPassword')
     def homsOrderCode = execution.getVariable('homsOrderCode')
 
-    def httpProcessor = new HTTPRestProcessor(execution: execution, baseUrl: "$homsUrl/api/")
+    def httpProcessor = new HTTPRestProcessor(baseUrl: "$homsUrl/api/")
     httpProcessor.httpClient.auth.basic(homsUser, homsPassword)
 
-    def homsResp = httpProcessor.sendRequest('get', path: "orders/$homsOrderCode", execution: execution)
+    def homsResp = httpProcessor.sendRequest('get', path: "orders/$homsOrderCode", logger: logger)
     def orderObj = homsResp["order"]
     def orderData = orderObj["data"].collectEntries{[it.key, it.value]}
 
@@ -24,13 +27,11 @@ public class GetOrderData extends AbstractListener {
     execution.setVariable("homsOrdDataBuffer", orderData)
   }
 
-  def execute(DelegateExecution execution) {
-    def homsUrl = execution.getVariable('homsUrl')
-    def homsUser = execution.getVariable('homsUser')
-    def homsPassword = execution.getVariable('homsPassword')
+  def notify(DelegateExecution execution) {
+    def logger = Logging.getLogger(execution)
 
-    log('/ Receiving order data...', "info", execution)
-    getOrderData(homsUrl, homsUser, homsPassword, execution)
-    log('\\ Order data received', "info", execution)
+    Logging.log('/ Receiving order data...', "info", logger)
+    getOrderData(execution, logger)
+    Logging.log('\\ Order data received', "info", logger)
   }
 }

--- a/src/homs/executionListeners/save_order_data.groovy
+++ b/src/homs/executionListeners/save_order_data.groovy
@@ -32,7 +32,7 @@ class SaveOrderData extends AbstractListener {
     httpProcessor.sendRequest('put', path: "orders/$homsOrderCode", body: homsRequestObj, logger: logger)
   }
 
-  def notify(DelegateExecution execution) {
+  void notify(DelegateExecution execution) {
     def logger = Logging.getLogger(execution)
 
     Logging.log('/ Saving order data...', "info", logger)

--- a/src/homs/executionListeners/save_order_data.groovy
+++ b/src/homs/executionListeners/save_order_data.groovy
@@ -3,6 +3,7 @@ package org.activiti.latera.homs.executionListeners
 import org.activiti.latera.bss.executionListeners.AbstractListener
 import org.activiti.engine.delegate.Expression
 import org.activiti.latera.bss.http.HTTPRestProcessor
+import org.activiti.engine.delegate.DelegateExecution
 
 public class SaveOrderData extends AbstractListener {
   
@@ -27,7 +28,7 @@ public class SaveOrderData extends AbstractListener {
     httpProcessor.sendRequest('put', path: "orders/$homsOrderCode", body: homsRequestObj, execution: execution)
   }
 
-  def execute(execution) {
+  def execute(DelegateExecution execution) {
     def homsUrl = execution.getVariable('homsUrl')
     def homsUser = execution.getVariable('homsUser')
     def homsPassword = execution.getVariable('homsPassword')

--- a/src/homs/executionListeners/save_order_data.groovy
+++ b/src/homs/executionListeners/save_order_data.groovy
@@ -1,14 +1,18 @@
 package org.activiti.latera.homs.executionListeners
 
 import org.activiti.latera.bss.executionListeners.AbstractListener
-import org.activiti.engine.delegate.Expression
 import org.activiti.latera.bss.http.HTTPRestProcessor
 import org.activiti.engine.delegate.DelegateExecution
+import org.activiti.latera.bss.logging.Logging
 
-public class SaveOrderData extends AbstractListener {
+class SaveOrderData extends AbstractListener {
   
-  def saveOrderData(def homsUrl, def homsUser, def homsPassword, def execution) {
+  def saveOrderData(def execution, def logger) {
+    def homsUrl = execution.getVariable('homsUrl')
+    def homsUser = execution.getVariable('homsUser')
+    def homsPassword = execution.getVariable('homsPassword')
     def homsOrderCode = execution.getVariable('homsOrderCode')
+
     def homsRequestObj = [
       order: [
         data: [:]
@@ -17,24 +21,22 @@ public class SaveOrderData extends AbstractListener {
 
     for (e in execution.getVariables()) {
       if (!e.key.startsWith('homsOrderData')) continue
-      
+
       def dataKey = e.key.replaceFirst(/^homsOrderData/, "")
       dataKey = (dataKey.getAt(0).toLowerCase() + dataKey.substring(1)).toString()
       homsRequestObj.order.data[dataKey] = e.value
     }
 
-    def httpProcessor = new HTTPRestProcessor(execution: execution, baseUrl: "$homsUrl/api/")
+    def httpProcessor = new HTTPRestProcessor(baseUrl: "$homsUrl/api/")
     httpProcessor.httpClient.auth.basic(homsUser, homsPassword)
-    httpProcessor.sendRequest('put', path: "orders/$homsOrderCode", body: homsRequestObj, execution: execution)
+    httpProcessor.sendRequest('put', path: "orders/$homsOrderCode", body: homsRequestObj, logger: logger)
   }
 
-  def execute(DelegateExecution execution) {
-    def homsUrl = execution.getVariable('homsUrl')
-    def homsUser = execution.getVariable('homsUser')
-    def homsPassword = execution.getVariable('homsPassword')
+  def notify(DelegateExecution execution) {
+    def logger = Logging.getLogger(execution)
 
-    log('/ Saving order data...', "info", execution)
-    saveOrderData(homsUrl, homsUser, homsPassword, execution)
-    log('\\ Order data saved', "info", execution)
+    Logging.log('/ Saving order data...', "info", logger)
+    saveOrderData(execution, logger)
+    Logging.log('\\ Order data saved', "info", logger)
   }
 }

--- a/src/homs/executionListeners/save_order_data.groovy
+++ b/src/homs/executionListeners/save_order_data.groovy
@@ -5,14 +5,6 @@ import org.activiti.engine.delegate.Expression
 import org.activiti.latera.bss.http.HTTPRestProcessor
 
 public class SaveOrderData extends AbstractListener {
-  private Expression homsUrl
-  private Expression homsUser
-  private Expression homsPassword
-  
-  def getParameterValue(def parameterName, def execution) {
-    def parameter = this."$parameterName"
-    parameter ? (String)parameter.getValue(execution) : execution.getVariable(parameterName)
-  }
   
   def saveOrderData(def homsUrl, def homsUser, def homsPassword, def execution) {
     def homsOrderCode = execution.getVariable('homsOrderCode')
@@ -32,16 +24,16 @@ public class SaveOrderData extends AbstractListener {
 
     def httpProcessor = new HTTPRestProcessor(execution: execution, baseUrl: "$homsUrl/api/")
     httpProcessor.httpClient.auth.basic(homsUser, homsPassword)
-    httpProcessor.sendRequest('put', path: "orders/$homsOrderCode", body: homsRequestObj)
+    httpProcessor.sendRequest('put', path: "orders/$homsOrderCode", body: homsRequestObj, execution: execution)
   }
 
-  def execute() {
-    def homsUrl = getParameterValue('homsUrl', execution)
-    def homsUser = getParameterValue('homsUser', execution)
-    def homsPassword = getParameterValue('homsPassword', execution)
+  def execute(execution) {
+    def homsUrl = execution.getVariable('homsUrl')
+    def homsUser = execution.getVariable('homsUser')
+    def homsPassword = execution.getVariable('homsPassword')
 
-    log '/ Saving order data...'
+    log('/ Saving order data...', "info", execution)
     saveOrderData(homsUrl, homsUser, homsPassword, execution)
-    log '\\ Order data saved'
+    log('\\ Order data saved', "info", execution)
   }
 }

--- a/src/homs/executionListeners/start_order.groovy
+++ b/src/homs/executionListeners/start_order.groovy
@@ -3,6 +3,7 @@ package org.activiti.latera.homs.executionListeners
 import org.activiti.engine.delegate.Expression
 import org.activiti.latera.bss.executionListeners.AbstractListener
 import org.activiti.latera.bss.http.HTTPRestProcessor
+import org.activiti.engine.delegate.DelegateExecution
 
 public class StartOrder extends AbstractListener {
   
@@ -24,7 +25,7 @@ public class StartOrder extends AbstractListener {
     httpProcessor.sendRequest('put', path: "orders/$homsOrderCode", body: homsRequestObj, execution: execution)
   }
 
-  def execute(execution) {
+  def execute(DelegateExecution execution) {
     def homsUrl = execution.getVariable('homsUrl')
     def homsUser = execution.getVariable('homsUser')
     def homsPassword = execution.getVariable('homsPassword')

--- a/src/homs/executionListeners/start_order.groovy
+++ b/src/homs/executionListeners/start_order.groovy
@@ -1,15 +1,19 @@
 package org.activiti.latera.homs.executionListeners
 
-import org.activiti.engine.delegate.Expression
 import org.activiti.latera.bss.executionListeners.AbstractListener
 import org.activiti.latera.bss.http.HTTPRestProcessor
 import org.activiti.engine.delegate.DelegateExecution
+import org.activiti.latera.bss.logging.Logging
 
-public class StartOrder extends AbstractListener {
+class StartOrder extends AbstractListener {
   
-  def startOrder(def homsUrl, def homsUser, def homsPassword, def execution) {
+  def startOrder(def execution, def logger) {
+    def homsUrl = execution.getVariable('homsUrl')
+    def homsUser = execution.getVariable('homsUser')
+    def homsPassword = execution.getVariable('homsPassword')
     def homsOrderCode = execution.getVariable('homsOrderCode')
     def initiatorEmail = execution.getVariable('initiatorEmail')
+
     def homsRequestObj = [
       order: [
         state: "in_progress",
@@ -20,18 +24,16 @@ public class StartOrder extends AbstractListener {
       ]
     ]
 
-    def httpProcessor = new HTTPRestProcessor(execution: execution, baseUrl: "$homsUrl/api/")
+    def httpProcessor = new HTTPRestProcessor(baseUrl: "$homsUrl/api/")
     httpProcessor.httpClient.auth.basic(homsUser, homsPassword)
-    httpProcessor.sendRequest('put', path: "orders/$homsOrderCode", body: homsRequestObj, execution: execution)
+    httpProcessor.sendRequest('put', path: "orders/$homsOrderCode", body: homsRequestObj, logger: logger)
   }
 
-  def execute(DelegateExecution execution) {
-    def homsUrl = execution.getVariable('homsUrl')
-    def homsUser = execution.getVariable('homsUser')
-    def homsPassword = execution.getVariable('homsPassword')
+  def notify(DelegateExecution execution) {
+    def logger = Logging.getLogger(execution)
 
-    log('/ Starting order...', "info", execution)
-    startOrder(homsUrl, homsUser, homsPassword, execution)
-    log("\\ Order started", "info", execution)
+    Logging.log('/ Starting order...', "info", logger)
+    startOrder(execution, logger)
+    Logging.log("\\ Order started", "info", logger)
   }
 }

--- a/src/homs/executionListeners/start_order.groovy
+++ b/src/homs/executionListeners/start_order.groovy
@@ -5,14 +5,6 @@ import org.activiti.latera.bss.executionListeners.AbstractListener
 import org.activiti.latera.bss.http.HTTPRestProcessor
 
 public class StartOrder extends AbstractListener {
-  private Expression homsUrl
-  private Expression homsUser
-  private Expression homsPassword
-  
-  def getParameterValue(def parameterName, def execution) {
-    def parameter = this."$parameterName"
-    parameter ? (String)parameter.getValue(execution) : execution.getVariable(parameterName)
-  }
   
   def startOrder(def homsUrl, def homsUser, def homsPassword, def execution) {
     def homsOrderCode = execution.getVariable('homsOrderCode')
@@ -29,16 +21,16 @@ public class StartOrder extends AbstractListener {
 
     def httpProcessor = new HTTPRestProcessor(execution: execution, baseUrl: "$homsUrl/api/")
     httpProcessor.httpClient.auth.basic(homsUser, homsPassword)
-    httpProcessor.sendRequest('put', path: "orders/$homsOrderCode", body: homsRequestObj)
+    httpProcessor.sendRequest('put', path: "orders/$homsOrderCode", body: homsRequestObj, execution: execution)
   }
 
-  def execute() {
-    def homsUrl = getParameterValue('homsUrl', execution)
-    def homsUser = getParameterValue('homsUser', execution)
-    def homsPassword = getParameterValue('homsPassword', execution)
+  def execute(execution) {
+    def homsUrl = execution.getVariable('homsUrl')
+    def homsUser = execution.getVariable('homsUser')
+    def homsPassword = execution.getVariable('homsPassword')
 
-    log '/ Starting order...'    
+    log('/ Starting order...', "info", execution)
     startOrder(homsUrl, homsUser, homsPassword, execution)
-    log "\\ Order started"
+    log("\\ Order started", "info", execution)
   }
 }

--- a/src/homs/executionListeners/start_order.groovy
+++ b/src/homs/executionListeners/start_order.groovy
@@ -29,7 +29,7 @@ class StartOrder extends AbstractListener {
     httpProcessor.sendRequest('put', path: "orders/$homsOrderCode", body: homsRequestObj, logger: logger)
   }
 
-  def notify(DelegateExecution execution) {
+  void notify(DelegateExecution execution) {
     def logger = Logging.getLogger(execution)
 
     Logging.log('/ Starting order...', "info", logger)


### PR DESCRIPTION
**Warning!**
The newly uploaded/started processes have to:

- import `org.activiti.latera.bss.logging.Logging` on each scripttask where logging is needed
- get rid of "def log" method and use `Logging.log(String msg, String level='info', Logger logger=null)` method instead
- get rid of "def logger = execution.getVariable('logger')" and use `def logger = Logging.getLogger(execution)` instead

Keep in mind that `Logging.log "${msg}"` would still work but without logger passed it will perform `println("[${level}] ${msg}")` instead so there will be no process id in log output
Same goes to HTTPRestProcessor.sendRequest - it has to have a `logger=logger` parameter otherwise logs will be just println-ed to catalina.out